### PR TITLE
Create generalized bb functions

### DIFF
--- a/lib/binaryaudit/util.py
+++ b/lib/binaryaudit/util.py
@@ -1,0 +1,10 @@
+def note(*args):
+    print(''.join(args))
+
+
+def warn(*args):
+    print("WARNING: " + ''.join(args))
+
+
+def error(*args):
+    print("ERROR: " + ''.join(args))


### PR DESCRIPTION
Generalize bb.note, bb.warn, and bb.error in util.py. Use these functions in abicheck.bbclass if the bb functions cannot be imported.