### PR TITLE
allow for global and recipe suppressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,26 @@ with a baseline ABI data from a previous build. This requires the variable below
 
 `BINARY_AUDIT_REFERENCE_BASEDIR = "/path/to/buildhistory.baseline"`
 
+# Suppressions
+
+In order to add a global suppression file, modify the variable `GLOBAL_SUPPRESSION_FILE` in `local.conf` to be the suppression's filepath:
+
+`GLOBAL_SUPRESSION_FILE = "/path/to/suppression.file"`
+
+To add recipe-specific suppressions, add the filepath to the suppression to the recipe's `SRC_URI` list. The suppression file must also have a name which follows the regex `abi*.suppr`. Here is an example for adding a suppression called `abi_openssl.suppr` to the `openssl` recipe:
+
+Suppression file is located in `/path.to.poky/poky/meta/recipes-connectivity/openssl/openssl/abi_openssl.suppr`
+
+The `SCR_URI` variable in `/path.to.poky/poky/meta/recipes-connectivity/openssl/openssl_1.1.1k.bb` looks like this:
+
+```
+SRC_URI = "http://www.openssl.org/source/openssl-${PV}.tar.gz \
+           file://run-ptest \
+           file://0001-skip-test_symbol_presence.patch \
+           file://0001-buildinfo-strip-sysroot-and-debug-prefix-map-from-co.patch \
+           file://afalg.patch \
+           file://reproducible.patch \
+           file://abi_openssl.suppr \
+           "
+```
+By adding a suppression file in this manner, it will show up in the recipe's `WORKDIR` and added to the `abidiff --suppression` call.

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -51,6 +51,9 @@ python binary_audit_abixml_compare_to_ref() {
 
     pn = d.getVar("PN")
     
+    util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
+    util.note("FILESEXTRAPATHS {}".format(d.getVar("FILESEXTRAPATHS")))
+    
     try:
         suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]
     except:

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -51,13 +51,10 @@ python binary_audit_abixml_compare_to_ref() {
 
     pn = d.getVar("PN")
     
-    util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
-    
-    util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
-    recipe_suppr = d.getVar("WORKDIR") + "/*_recipe.suppr"
+ 
+    recipe_suppr = d.getVar("WORKDIR") + "/abi*.suppr"
     
     suppr = glob.glob(recipe_suppr)
-    util.note("RECIPE SUPPRESSION: ".format(str(suppr)))
 
     if os.path.isfile(str(d.getVar("GLOBAL_SUPPRESSION_FILE"))):
         suppr += [d.getVar("GLOBAL_SUPPRESSION_FILE")]

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -54,15 +54,11 @@ python binary_audit_abixml_compare_to_ref() {
     util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
     
     util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
-    recipe_suppr = d.getVar("WORKDIR") + "/recipe.suppr"
-    util.note("RECIPE SUPPRESSION: {}".format(recipe_suppr))
-    util.note("IS FILE: " + str(os.path.isfile(recipe_suppr)))
+    recipe_suppr = d.getVar("WORKDIR") + "/*_recipe.suppr"
     
-    if os.path.isfile(recipe_suppr):
-        suppr = [recipe_suppr]
-    else:
-        suppr = []
-    
+    suppr = glob.glob(recipe_suppr)
+    util.note("RECIPE SUPPRESSION: ".format(str(suppr)))
+
     if os.path.isfile(str(d.getVar("GLOBAL_SUPPRESSION_FILE"))):
         suppr += [d.getVar("GLOBAL_SUPPRESSION_FILE")]
     else:

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -52,7 +52,7 @@ python binary_audit_abixml_compare_to_ref() {
     pn = d.getVar("PN")
     
     util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
-    util.note("FILESEXTRAPATHS {}".format(d.getVar("FILESEXTRAPATHS")))
+    util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
     
     try:
         suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -54,7 +54,7 @@ python binary_audit_abixml_compare_to_ref() {
     util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
     
     util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
-    recipe_suppr = d.getVar("WORKDIR")[:-1] + "/test_recipe.suppr"
+    recipe_suppr = d.getVar("WORKDIR") + "/test_recipe.suppr"
     util.note("RECIPE SUPPRESSION: {}".format(recipe_suppr))
     util.note(str(os.path.isfile(recipe_suppr)))
     

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -51,7 +51,7 @@ python binary_audit_abixml_compare_to_ref() {
 
     pn = d.getVar("PN")
     try:
-        suppr = d.getVar("GLOBAL_SUPPRESSION_FILE")
+        suppr = d.getVar("GLOBAL_SUPPRESSION_FILE").split(", ")
     except:
         util.note("getVar exception raised")
         suppr = []

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -50,6 +50,8 @@ python binary_audit_abixml_compare_to_ref() {
     t0 = time.monotonic()
 
     pn = d.getVar("PN")
+    
+    suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]
 
     dest_basedir = binary_audit_get_create_pkg_dest_basedir(d)
     cur_abixml_dir = os.path.join(dest_basedir, "abixml")
@@ -97,7 +99,7 @@ python binary_audit_abixml_compare_to_ref() {
             # XXX Handle error cases, eg xml file was garbage, etc.
             if len(sn) > 0:
                 # XXX Implement suppression handling
-                ret, out, cmd = abicheck.compare(ref_xml_fpath, cur_xml_fpath)
+                ret, out, cmd = abicheck.compare(ref_xml_fpath, cur_xml_fpath, suppr)
 
                 util.note(" ".join(cmd))
 

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -52,13 +52,24 @@ python binary_audit_abixml_compare_to_ref() {
     pn = d.getVar("PN")
     
     util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
+    
     util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
+    recipe_suppr = d.getVar("WORKDIR")[:-1] + "/test_recipe.suppr"
+    util.note("RECIPE SUPPRESSION: {}".format(recipe_suppr))
+    util.note(str(os.path.isfile(recipe_suppr)))
+    
+    if os.path.isfile(recipe_suppr):
+        suppr = [recipe_suppr]
+    else:
+        suppr = []
     
     try:
-        suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]
+        suppr += [d.getVar("GLOBAL_SUPPRESSION_FILE")]
     except:
         util.note("getVar exception raised")
-        suppr = []
+        
+    util.note("SUPPRESSION FILES: {}".format(str(suppr)))
+
 
     dest_basedir = binary_audit_get_create_pkg_dest_basedir(d)
     cur_abixml_dir = os.path.join(dest_basedir, "abixml")

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -54,19 +54,19 @@ python binary_audit_abixml_compare_to_ref() {
     util.note("FILESPATH {}".format(d.getVar("FILESPATH")))
     
     util.note("WORKDIR {}".format(d.getVar("WORKDIR")))
-    recipe_suppr = d.getVar("WORKDIR") + "/test_recipe.suppr"
+    recipe_suppr = d.getVar("WORKDIR") + "/recipe.suppr"
     util.note("RECIPE SUPPRESSION: {}".format(recipe_suppr))
-    util.note(str(os.path.isfile(recipe_suppr)))
+    util.note("IS FILE: " + str(os.path.isfile(recipe_suppr)))
     
     if os.path.isfile(recipe_suppr):
         suppr = [recipe_suppr]
     else:
         suppr = []
     
-    try:
+    if os.path.isfile(str(d.getVar("GLOBAL_SUPPRESSION_FILE"))):
         suppr += [d.getVar("GLOBAL_SUPPRESSION_FILE")]
-    except:
-        util.note("getVar exception raised")
+    else:
+        util.note("No global suppression found")
         
     util.note("SUPPRESSION FILES: {}".format(str(suppr)))
 

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -50,8 +50,11 @@ python binary_audit_abixml_compare_to_ref() {
     t0 = time.monotonic()
 
     pn = d.getVar("PN")
-    
-    suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]
+    try:
+        suppr = d.getVar("GLOBAL_SUPPRESSION_FILE")
+    except:
+        util.note("getVar exception raised")
+        suppr = []
 
     dest_basedir = binary_audit_get_create_pkg_dest_basedir(d)
     cur_abixml_dir = os.path.join(dest_basedir, "abixml")

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -50,8 +50,9 @@ python binary_audit_abixml_compare_to_ref() {
     t0 = time.monotonic()
 
     pn = d.getVar("PN")
+    
     try:
-        suppr = d.getVar("GLOBAL_SUPPRESSION_FILE").split(", ")
+        suppr = [d.getVar("GLOBAL_SUPPRESSION_FILE")]
     except:
         util.note("getVar exception raised")
         suppr = []

--- a/lib/binaryaudit/abicheck.py
+++ b/lib/binaryaudit/abicheck.py
@@ -39,8 +39,11 @@ def serialize(fn):
     return process.returncode, out, cmd
 
 
-def compare(ref, cur):
-    cmd = ["abidiff", ref, cur]
+def compare(ref, cur, suppr=[]):
+    cmd = ["abidiff"]
+    for sup_fn in suppr:
+        cmd += ["--suppr", sup_fn]
+    cmd += [ref, cur]
     sout = subprocess.PIPE
     serr = subprocess.STDOUT
     shell = False


### PR DESCRIPTION
A global and a recipe-specific suppression file can be used for a recipe. The recipe-specific suppression has to be named as "*_recipe.suppr", and added to the recipe so that it shows up in WORKDIR. The global suppression file is the value assigned to "GLOBAL_SUPPRESSION_FILE" in local.conf.