### PR TITLE
Escape symbol name attribute

### DIFF
--- a/recipes-devtools/libabigail/libabigail/0001-Escape-the-value-of-the-symbols-name-attribute.patch
+++ b/recipes-devtools/libabigail/libabigail/0001-Escape-the-value-of-the-symbols-name-attribute.patch
@@ -1,0 +1,30 @@
+From 14ab99549fca49540330136326ed844b0dcd9958 Mon Sep 17 00:00:00 2001
+From: Pavel Zhukov <pavel.zhukov@huawei.com>
+Date: Tue, 11 Jan 2022 14:06:01 +0100
+Subject: [PATCH] Escape the value of the symbols name attribute
+Cc: pavel@zhukoff.net
+
+Symbols name may include < and > characters (go-runtime is an example)
+which causes xml parsers to fail.
+
+Signed-off-by: Pavel Zhukov <pavel.zhukov@huawei.com>
+---
+ src/abg-writer.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/abg-writer.cc b/src/abg-writer.cc
+index 76ce809b..e2239e01 100644
+--- a/src/abg-writer.cc
++++ b/src/abg-writer.cc
+@@ -3111,7 +3111,7 @@ write_elf_symbol(const elf_symbol_sptr&	sym,
+ 
+   annotate(sym, ctxt, indent);
+   do_indent(o, indent);
+-  o << "<elf-symbol name='" << sym->get_name() << "'";
++  o << "<elf-symbol name='" << xml::escape_xml_string(sym->get_name()) << "'";
+   if (sym->is_variable() && sym->get_size())
+   o << " size='" << sym->get_size() << "'";
+ 
+-- 
+2.34.1
+

--- a/recipes-devtools/libabigail/libabigail_1.8.2.bb
+++ b/recipes-devtools/libabigail/libabigail_1.8.2.bb
@@ -7,7 +7,8 @@ SHA512SUM="fa8edaf39632e26430481f15e962a098459eac087074e85ca055293ba324ec5944c45
 SRC_URI[md5sum] = "bd8509b286ff39fe82107a3847ee9f39"
 SRC_URI[sha256sum] = "86347c9f0a8666f263fd63f8c3fe4c4f9cb1bdb3ec4260ecbaf117d137e89787"
 
-SRC_URI = "https://mirrors.kernel.org/sourceware/libabigail/libabigail-${PV}.tar.gz;sha512sum=${SHA512SUM}"
+SRC_URI = "https://mirrors.kernel.org/sourceware/libabigail/libabigail-${PV}.tar.gz;sha512sum=${SHA512SUM} \
+           file://0001-Escape-the-value-of-the-symbols-name-attribute.patch "
 
 LIC_FILES_CHKSUM = " \
     file://COPYING;md5=2b3c1a10dd8e84f2db03cb00825bcf95 \


### PR DESCRIPTION
Symbol name attribute is not escaped and may causes failures.
Sent upstream: https://sourceware.org/pipermail/libabigail/2022q1/004060.html

Signed-off-by: Pavel Zhukov <pavel.zhukov@huawei.com>

