### PR TITLE
Make the ABI comparison a Package QA test

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,28 @@ The included libabigail recipe is configurable the usual way through [PACKAGECON
 
 ## ABI serialization
 
-The ABI check can be activated by appending the `abicheck` bbclass to the bbclass inherit list. The class will attach several function calls to the recipe `install` tasks, in order to handle creation and further usage of the ABI related data. In `local.conf`, the following is to be added:
+The ABI check can be activated by appending the `abicheck` bbclass to the bbclass inherit list. The class will attach several function calls to the recipe `install` tasks, in order to handle creation and further usage of the ABI related data. In your `local.conf`, add the following:
 
-`INHERIT += "abicheck"`
+```bitbake
+INHERIT += "abicheck"
+```
 
-The tool used for the ABI info serialization is [abidw](https://sourceware.org/libabigail/manual/abidw.html).
+With the class inherited, the serialized ABI representation will be integrated into the build history. Saving the build history will allow us to compare the current build
+with a baseline ABI data from a previous build.
 
-## ABI compatibility
+After your first build to collect baseline data, set the variable below to the buildhistory directory, which we now take as a baseline:
 
-The serialized ABI representation will be integrated into the build history. Saving the build history will allow to compare the current build
-with a baseline ABI data from a previous build. This requires the variable below to be set to a buildhistory directory to be taken as a baseline:
+```bitbake
+BINARY_AUDIT_REFERENCE_BASEDIR = "/path/to/buildhistory.baseline"
+```
 
-`BINARY_AUDIT_REFERENCE_BASEDIR = "/path/to/buildhistory.baseline"`
+The ABI comparison is done during [the Package QA mechanism](https://docs.yoctoproject.org/3.2/ref-manual/ref-qa-checks.html), allowing you to control whether if an ABI change is an error or a warning.  Then, to enable alerting for ABI changes, add the `abi-changed` QA test using _one of_ the lines here:
+
+```bitbake
+WARN_QA_append = " abi-changed"
+# --- or ---
+ERROR_QA_append = " abi-changed"
+```
 
 The tools used to perform the compatibility verification is [abicompat](https://sourceware.org/libabigail/manual/abicompat.html).
 

--- a/classes/abicheck.bbclass
+++ b/classes/abicheck.bbclass
@@ -1,5 +1,6 @@
 
 inherit binaryaudit
+inherit insane
 
 BUILDHISTORY_FEATURES += "abicheck"
 
@@ -53,7 +54,8 @@ python binary_audit_gather_abixml() {
 do_install[postfuncs] += "${@ "binary_audit_gather_abixml" if ("class-target" == d.getVar("CLASSOVERRIDE")) else "" }"
 do_install[vardepsexclude] += "${@ "binary_audit_gather_abixml" if ("class-target" == d.getVar("CLASSOVERRIDE")) else "" }"
 
-python binary_audit_abixml_compare_to_ref() {
+QAPATHTEST[abi-changed] = "package_qa_binary_audit_abixml_compare_to_ref"
+def package_qa_binary_audit_abixml_compare_to_ref(file, name, d, elf, messages):
     import glob, os, time
     from binaryaudit import util
     from binaryaudit import abicheck
@@ -61,8 +63,8 @@ python binary_audit_abixml_compare_to_ref() {
     t0 = time.monotonic()
 
     pn = d.getVar("PN")
+
     
- 
     recipe_suppr = d.getVar("WORKDIR") + "/abi*.suppr"
     
     suppr = glob.glob(recipe_suppr)
@@ -149,8 +151,10 @@ python binary_audit_abixml_compare_to_ref() {
                 status_ln = " ".join(status_bits)
                 # XXX Just warn for now if there's anythnig non 0 in the status.
                 #     Should be made finer configurable through local.conf.
-                util.warn("abicheck: {} diff bits: {}".format(sn, "".join(status_ln)))
-                #bb.error("abicheck output: '{}'".format(out))
+                util.add_message(messages, 'abi-changed',
+                                '%s: ABI changed from reference build, logs: %s'
+                                % (name, out))
+
 
     t1 = time.monotonic()
     duration_fl = cur_abidiff_dir + ".duration"
@@ -158,8 +162,4 @@ python binary_audit_abixml_compare_to_ref() {
     with open(duration_fl, "w") as f:
         f.write(u"{}".format(t1 - t0))
         f.close()
-}
 
-# Target binaries are the only interest.
-do_install[postfuncs] += "${@ "binary_audit_abixml_compare_to_ref" if ("class-target" == d.getVar("CLASSOVERRIDE")) else "" }"
-do_install[vardepsexclude] += "${@ "binary_audit_abixml_compare_to_ref" if ("class-target" == d.getVar("CLASSOVERRIDE")) else "" }"

--- a/lib/binaryaudit/util.py
+++ b/lib/binaryaudit/util.py
@@ -118,3 +118,13 @@ def create_path_to_xml(sn, adir, fn):
         out_fn = os.path.join(adir, ".".join([os.path.basename(fn), "xml"]))
 
     return out_fn
+
+
+# Add or append to a QA message.
+# This helper method was renamed after honister, so we implement our
+# own here so that it would work across versions.
+def add_message(messages, section, new_msg):
+    if section not in messages:
+        messages[section] = new_msg
+    else:
+        messages[section] = messages[section] + "\n" + new_msg


### PR DESCRIPTION
The abicheck class currently hooks two functions after the do_install step: one to gather the ABI data for this build, and one to perform the ABI comparison if a baseline is available.

We now use Package QA instead to do the ABI comparison, allowing a user to specify whether if they want an ABI change to be a warning or an error.
